### PR TITLE
fix: SSE 알림 스트림 URL을 환경에 따라 자동 적용되도록 api.js의 API_BASE_URL 사용

### DIFF
--- a/src/hooks/use-notification.js
+++ b/src/hooks/use-notification.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import notificationService from '../services/notificationService';
+import api from '../services/api';
 
 export function useNotification() {
   const [isConnected, setIsConnected] = useState(false);
@@ -28,12 +29,11 @@ export function useNotification() {
         eventSourceRef.current.close();
       }
 
-      const es = new EventSource(
-        `http://localhost:3001/notification/stream/?clientName=${encodeURIComponent(
-          username
-        )}`,
-        { withCredentials: false }
-      );
+      const eventSourceUrl = `${api.API_BASE_URL}/notification/stream/?clientName=${encodeURIComponent(
+        username
+      )}`;
+
+      const es = new EventSource(eventSourceUrl, { withCredentials: true });
 
       es.onopen = () => {
         console.log('SSE 연결 성공');


### PR DESCRIPTION
## 🧐 어떤 PR인가요? (What's in this PR?)

- 알림 SSE 스트림 URL을 환경에 따라 자동 적용되도록 개선
- use-notification.js에서 알림 스트림(EventSource) URL 하드코딩 제거 및 api.js의 API_BASE_URL 사용

### 🖥️ Frontend 작업 내용

- [x] use-notification.js에서 EventSource 생성 시 api.js의 API_BASE_URL을 활용하도록 수정
- [x] 로컬/운영 환경 모두에서 알림 SSE가 정상 동작하도록 환경별 URL 자동 적용
 
## ✅ PR Checklist

**기본 사항**

- [x]  스스로 코드를 다시 한번 검토했나요? (Self-review)
- [x]  PR 제목은 명확하고 작업 내용을 잘 요약하고 있나요?
- [x]  불필요한 console.log, 주석 등을 제거했나요?
- [x]  코드 스타일 가이드라인을 준수했나요? (Lint 검사 통과)

**기능 구현 및 테스트**

- [x]  새로운 기능이 문제없이 작동하나요?
- [x]  기존 기능에 영향을 주지 않나요? (회귀 테스트)

**추가 확인 사항**

- [x]  성능에 영향을 줄 수 있는 코드가 있다면, 최적화 방안을 고려했나요?
- [x]  민감한 정보(API 키, 비밀번호 등)가 코드에 포함되지 않았나요?
- [x]  의존성 변경 사항이 있다면, `package.json` 또는 `yarn.lock` (또는 해당 파일)이 올바르게 업데이트되었나요?
